### PR TITLE
Fix: Resolve post-merge hook validation issues

### DIFF
--- a/js/performance-monitor.js
+++ b/js/performance-monitor.js
@@ -18,6 +18,9 @@
 
 class PerformanceMonitor {
     constructor() {
+    // Detect test environment to suppress warnings
+        this.isTestEnvironment = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
+        
     // Core metrics storage
         this.metrics = {
             // Core Web Vitals
@@ -439,7 +442,9 @@ class PerformanceMonitor {
 
     initializeMemoryMonitoring() {
         if (!('memory' in performance)) {
-            console.warn('[PerfMonitor] Memory API not supported');
+            if (!this.isTestEnvironment) {
+                console.warn('[PerfMonitor] Memory API not supported');
+            }
             return;
         }
 
@@ -481,7 +486,9 @@ class PerformanceMonitor {
 
     initializeNetworkMonitoring() {
         if (!('connection' in navigator)) {
-            console.warn('[PerfMonitor] Network Information API not supported');
+            if (!this.isTestEnvironment) {
+                console.warn('[PerfMonitor] Network Information API not supported');
+            }
             return;
         }
 
@@ -965,9 +972,13 @@ class PerformanceMonitor {
                 );
 
                 if (success) {
-                    console.log('[PerfMonitor] Final report sent via sendBeacon');
+                    if (!this.isTestEnvironment) {
+                        console.log('[PerfMonitor] Final report sent via sendBeacon');
+                    }
                 } else {
-                    console.warn('[PerfMonitor] sendBeacon failed, attempting fetch');
+                    if (!this.isTestEnvironment) {
+                        console.warn('[PerfMonitor] sendBeacon failed, attempting fetch');
+                    }
                     this.fallbackFinalReport(finalReport);
                 }
             } else {
@@ -986,7 +997,9 @@ class PerformanceMonitor {
             xhr.setRequestHeader('Content-Type', 'application/json');
             xhr.send(JSON.stringify(reportData));
         } catch (error) {
-            console.error('[PerfMonitor] Fallback final report failed:', error);
+            if (!this.isTestEnvironment) {
+                console.error('[PerfMonitor] Fallback final report failed:', error);
+            }
         }
     }
 
@@ -1206,9 +1219,11 @@ class PerformanceMonitor {
                 );
 
                 if (!success) {
-                    console.warn(
-                        '[PerfMonitor] sendBeacon failed, falling back to fetch'
-                    );
+                    if (!this.isTestEnvironment) {
+                        console.warn(
+                            '[PerfMonitor] sendBeacon failed, falling back to fetch'
+                        );
+                    }
                     this.sendWithFetch(analyticsEndpoint, report);
                 }
             } else {

--- a/tests/unit/link-validation/test_link_validation.py
+++ b/tests/unit/link-validation/test_link_validation.py
@@ -326,15 +326,21 @@ class LinkValidator:
         # Remove leading slash and check if file exists
         clean_url = url.lstrip('/')
         
-        # Try with .html extension
-        html_file = self.project_root / f"{clean_url}.html"
-        if html_file.exists():
+        # First, check if URL already points to an existing file (e.g., already has .html)
+        direct_file = self.project_root / clean_url
+        if direct_file.exists() and direct_file.is_file():
             return True
         
-        # Try in pages directory
-        pages_file = self.pages_dir / f"{clean_url}.html"
-        if pages_file.exists():
-            return True
+        # Try with .html extension (if not already present)
+        if not clean_url.endswith('.html'):
+            html_file = self.project_root / f"{clean_url}.html"
+            if html_file.exists():
+                return True
+            
+            # Try in pages directory
+            pages_file = self.pages_dir / f"{clean_url}.html"
+            if pages_file.exists():
+                return True
         
         # Try as directory with index.html
         index_file = self.project_root / clean_url / "index.html"
@@ -404,8 +410,8 @@ class LinkValidator:
         url = link.url
         
         if url == '/':
-            # Root route redirects to index.html
-            return (self.project_root / "index.html").exists()
+            # Root route redirects to pages/index.html per vercel.json
+            return (self.project_root / "pages" / "index.html").exists()
         
         
         elif url.startswith('/gallery-data/') and url.endswith('.json'):


### PR DESCRIPTION
## Summary
- Fixed link validation to properly handle URLs with .html extension
- Updated root route validation to check pages/index.html per vercel.json config
- Added test environment detection to suppress browser API warnings in Performance Monitor

## Problem
After merging to main, the post-merge hook was failing due to:
1. Link validation incorrectly flagging valid URLs ending with `.html`
2. Root route `/` validation looking for wrong file location
3. Performance monitor tests generating thousands of console warnings about missing browser APIs

## Solution
1. **Link Validation Fix**: Modified `_validate_internal_page()` to check if URL already points to existing file before appending `.html`
2. **Root Route Fix**: Updated special route validation to check `pages/index.html` matching vercel.json routing
3. **Test Warnings Fix**: Added `isTestEnvironment` detection to suppress browser API warnings during tests

## Results
✅ All 770 links now validate successfully
✅ Unit tests run cleanly without stderr spam (935 tests passing)
✅ Post-merge hook completes without warnings

## Test Output
```
Test Files  54 passed | 1 skipped (55)
Tests  935 passed | 51 skipped (986)
```

🤖 Generated with [Claude Code](https://claude.ai/code)