### PR TITLE
fix: handle HTTP 409 status in email subscription test

### DIFF
--- a/tests/api-contracts.test.js
+++ b/tests/api-contracts.test.js
@@ -71,7 +71,7 @@ test('email subscription API validates and processes requests correctly', async 
     expect(response.data).toHaveProperty('error');
   }
   else {
-    expect([200, 201, HTTP_STATUS.BAD_REQUEST, HTTP_STATUS.TOO_MANY_REQUESTS].includes(response.status)).toBe(true);
+    expect([200, 201, HTTP_STATUS.BAD_REQUEST, HTTP_STATUS.CONFLICT, HTTP_STATUS.TOO_MANY_REQUESTS].includes(response.status)).toBe(true);
   }
 });
 


### PR DESCRIPTION
## Summary
Fixed failing CI test by adding HTTP 409 (Conflict) to expected status codes in email subscription test.

## Changes
- Added `HTTP_STATUS.CONFLICT` to expected status codes in `tests/api-contracts.test.js`
- CI server returns 409 when email already subscribed, but test only expected [200, 201, 400, 429]

## Test Results
✅ All 24 tests passing locally with CI server mock

## Context
The CI failures in [run 17226733803](https://github.com/damilola-elegbede/alocubano.boulderfest/actions/runs/17226733803) were caused by the email subscription test not handling the 409 status code that the CI mock server returns for duplicate subscriptions.