### PR TITLE
Fix admin dashboard redirect issue - correct Vercel routing configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -256,75 +256,51 @@
     },
     {
       "source": "/admin/login",
-      "destination": "/admin/login.html"
+      "destination": "/pages/admin/login.html"
     },
     {
       "source": "/admin/dashboard",
-      "destination": "/admin/dashboard.html"
+      "destination": "/pages/admin/dashboard.html"
     },
     {
       "source": "/admin/checkin",
-      "destination": "/admin/checkin.html"
+      "destination": "/pages/admin/checkin.html"
     },
     {
       "source": "/admin/analytics",
-      "destination": "/admin/analytics.html"
+      "destination": "/pages/admin/analytics.html"
     },
     {
       "source": "/admin/mfa-settings",
-      "destination": "/admin/mfa-settings.html"
+      "destination": "/pages/admin/mfa-settings.html"
     },
     {
       "source": "/admin",
-      "destination": "/admin/index.html"
+      "destination": "/pages/admin/index.html"
     },
     {
       "source": "/pages/admin/login",
-      "destination": "/admin/login.html"
+      "destination": "/pages/admin/login.html"
     },
     {
       "source": "/pages/admin/dashboard",
-      "destination": "/admin/dashboard.html"
+      "destination": "/pages/admin/dashboard.html"
     },
     {
       "source": "/pages/admin/checkin",
-      "destination": "/admin/checkin.html"
+      "destination": "/pages/admin/checkin.html"
     },
     {
       "source": "/pages/admin/analytics",
-      "destination": "/admin/analytics.html"
+      "destination": "/pages/admin/analytics.html"
     },
     {
       "source": "/pages/admin/mfa-settings",
-      "destination": "/admin/mfa-settings.html"
+      "destination": "/pages/admin/mfa-settings.html"
     },
     {
       "source": "/pages/admin",
-      "destination": "/admin/index.html"
-    },
-    {
-      "source": "/admin/login.html",
-      "destination": "/admin/login.html"
-    },
-    {
-      "source": "/admin/dashboard.html",
-      "destination": "/admin/dashboard.html"
-    },
-    {
-      "source": "/admin/checkin.html",
-      "destination": "/admin/checkin.html"
-    },
-    {
-      "source": "/admin/analytics.html",
-      "destination": "/admin/analytics.html"
-    },
-    {
-      "source": "/admin/mfa-settings.html",
-      "destination": "/admin/mfa-settings.html"
-    },
-    {
-      "source": "/admin/index.html",
-      "destination": "/admin/index.html"
+      "destination": "/pages/admin/index.html"
     },
     {
       "source": "/manifest.json",


### PR DESCRIPTION
## Summary
Fixed a critical routing issue that was preventing the admin dashboard from loading after login. The Vercel configuration was incorrectly rewriting admin URLs to non-existent file paths, causing 404 errors and redirects to the home page.

## Changes
- Updated `vercel.json` to correct admin page routing destinations from `/admin/*.html` to `/pages/admin/*.html`
- Removed 6 duplicate circular rewrite rules that were causing routing conflicts
- Standardized all admin route patterns to point to the correct file locations in `/pages/admin/`
- Reduced total rewrite rules from 18 to 12 by eliminating redundant entries

## Problem Solved
After successful admin login, users were being redirected to the home page instead of the dashboard because Vercel was looking for admin files in `/admin/` (which doesn't exist) instead of `/pages/admin/` where they actually reside.

## Test Plan
- [x] Admin login redirects to dashboard correctly
- [x] All admin pages accessible via both `/admin/*` and `/pages/admin/*` URLs
- [x] No more 404 errors on admin routes
- [x] Pre-commit hooks pass

## Impact
This fix restores full admin functionality, allowing administrators to access the dashboard, analytics, check-in scanner, and other critical features.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for /pages/admin/* routes (login, dashboard, check-in, analytics, MFA settings, index).

- Refactor
  - Reorganized admin routing under a /pages/admin structure.
  - /admin now routes to the new /pages/admin/index.

- Chores
  - Removed legacy /admin/*.html endpoints; direct .html URLs are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->