### PR TITLE
fix: resolve production bootstrap failure with test event status constraint

### DIFF
--- a/migrations/032_add_test_status_to_events.sql
+++ b/migrations/032_add_test_status_to_events.sql
@@ -1,0 +1,95 @@
+-- Migration: 032 - Add 'test' status to events table
+-- Purpose: Support test events in bootstrap configuration
+-- Dependencies: 003_events_table.sql
+-- Issue: Bootstrap fails because test events have status='test' but CHECK constraint doesn't allow it
+
+-- SQLite doesn't support modifying CHECK constraints directly
+-- We need to recreate the table with the updated constraint
+
+-- Disable foreign key checks temporarily to allow table recreation
+PRAGMA foreign_keys = OFF;
+
+-- Step 1: Create new events table with updated status constraint
+CREATE TABLE IF NOT EXISTS events_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL CHECK(type IN ('festival', 'weekender', 'workshop', 'special')),
+    status TEXT NOT NULL DEFAULT 'draft' CHECK(status IN ('draft', 'upcoming', 'active', 'completed', 'cancelled', 'test')),
+
+    -- Event Details
+    description TEXT,
+    venue_name TEXT,
+    venue_address TEXT,
+    venue_city TEXT DEFAULT 'Boulder',
+    venue_state TEXT DEFAULT 'CO',
+    venue_zip TEXT,
+
+    -- Event Dates
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    year INTEGER GENERATED ALWAYS AS (CAST(strftime('%Y', start_date) AS INTEGER)) STORED,
+
+    -- Capacity and Pricing
+    max_capacity INTEGER,
+    early_bird_end_date DATE,
+    regular_price_start_date DATE,
+
+    -- Display and Ordering
+    display_order INTEGER DEFAULT 0,
+    is_featured BOOLEAN DEFAULT FALSE,
+    is_visible BOOLEAN DEFAULT TRUE,
+
+    -- Metadata
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT,
+
+    -- Configuration (JSON for flexible event-specific settings)
+    config TEXT -- JSON stored as TEXT for SQLite compatibility
+);
+
+-- Step 2: Copy data from old table to new table (if old table exists and has data)
+INSERT INTO events_new (
+    id, slug, name, type, status, description,
+    venue_name, venue_address, venue_city, venue_state, venue_zip,
+    start_date, end_date, max_capacity,
+    early_bird_end_date, regular_price_start_date,
+    display_order, is_featured, is_visible,
+    created_at, updated_at, created_by, config
+)
+SELECT
+    id, slug, name, type, status, description,
+    venue_name, venue_address, venue_city, venue_state, venue_zip,
+    start_date, end_date, max_capacity,
+    early_bird_end_date, regular_price_start_date,
+    display_order, is_featured, is_visible,
+    created_at, updated_at, created_by, config
+FROM events
+WHERE EXISTS (SELECT 1 FROM events LIMIT 1);
+
+-- Step 3: Drop old table
+DROP TABLE IF EXISTS events;
+
+-- Step 4: Rename new table to original name
+ALTER TABLE events_new RENAME TO events;
+
+-- Step 5: Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_events_slug ON events(slug);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
+CREATE INDEX IF NOT EXISTS idx_events_year ON events(year);
+CREATE INDEX IF NOT EXISTS idx_events_status ON events(status);
+CREATE INDEX IF NOT EXISTS idx_events_dates ON events(start_date, end_date);
+CREATE INDEX IF NOT EXISTS idx_events_display_order ON events(display_order);
+CREATE INDEX IF NOT EXISTS idx_events_slug_status ON events(slug, status);
+CREATE INDEX IF NOT EXISTS idx_events_type_status ON events(type, status);
+
+-- Step 6: Recreate trigger for updated timestamp
+CREATE TRIGGER IF NOT EXISTS update_events_timestamp
+AFTER UPDATE ON events
+BEGIN
+    UPDATE events SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+-- Re-enable foreign key checks
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
## Summary
Fixes production deployment failure caused by missing 'test' status in events table CHECK constraint. Bootstrap was failing with FK constraint violations when trying to insert test ticket_types.

## Root Cause
- Events table (migration 003) only allowed statuses: `'draft', 'upcoming', 'active', 'completed', 'cancelled'`
- Bootstrap.json defines test events with `status='test'`
- `INSERT OR IGNORE` silently skipped test events due to CHECK constraint violation
- Ticket_types referencing non-existent test event IDs (-1, -2) triggered FK constraint failure

## Changes
- Add migration 032 to recreate events table with `'test'` status in CHECK constraint
- Fills gap in migration sequence (031→037) left by migration rewrite in commit 18a490c
- Handles table recreation safely with PRAGMA foreign_keys OFF/ON

## Why Preview Worked But Production Failed
- Preview deployments used persistent databases with existing data
- Production was fresh database running all migrations for first time
- This exposed the constraint mismatch between migrations and bootstrap data

## Testing
- Analyzed all CHECK constraints vs bootstrap.json data
- Verified all foreign key references are valid
- Confirmed no other migration failures possible
- Pre-commit and pre-push hooks passed

## Migration Details
**File**: `migrations/032_add_test_status_to_events.sql`
- Recreates events table with updated CHECK constraint
- Preserves all existing data
- Recreates all indexes and triggers
- Safe for production deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)