### PR TITLE
fix(ui): correct payment processor badge icons

### DIFF
--- a/pages/admin/dashboard.html
+++ b/pages/admin/dashboard.html
@@ -1033,7 +1033,7 @@
 
                               // Format payment processor information
                               const paymentProcessor = reg.payment_processor || 'stripe';
-                              const processorIcon = paymentProcessor === 'paypal' ? '💳' : '💰';
+                              const processorIcon = paymentProcessor === 'paypal' ? '🅿️' : '💳';
                               const processorBadge = paymentProcessor === 'paypal' ? 'paypal-badge' : 'stripe-badge';
                               const transactionId = reg.paypal_order_id || reg.stripe_session_id || reg.transaction_id;
 


### PR DESCRIPTION
## Summary
Fix payment processor badge icons in admin dashboard to be more intuitive and accurate.

## Changes
- **Stripe**: Now displays 💳 (credit card) - accurate for card processing
- **PayPal**: Now displays 🅿️ (P emoji) - closer to PayPal branding

## Context
Previous implementation had backwards/confusing icons:
- PayPal incorrectly showed 💳 (credit card icon)
- Stripe showed 💰 (money bag - not intuitive)

This small UI fix improves visual clarity when reviewing transactions in the admin dashboard.

## Testing
- Verified icon changes render correctly in admin dashboard
- Confirmed visual distinction between Stripe and PayPal transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)