### PR TITLE
fix(email): fix registration reminder email formatting and ticket display

### DIFF
--- a/lib/ticket-email-service-brevo.js
+++ b/lib/ticket-email-service-brevo.js
@@ -310,9 +310,9 @@ Test data may be automatically cleaned up periodically.
 
     return ticketDetails
       .map((ticket, index) =>
-        `${index + 1}. ${ticket.type}<br>&nbsp;&nbsp;&nbsp;${ticket.eventName}<br>&nbsp;&nbsp;&nbsp;${ticket.date}<br>&nbsp;&nbsp;&nbsp;${ticket.location}`
+        `${index + 1}. ${ticket.type}\n   ${ticket.eventName}\n   ${ticket.date}\n   ${ticket.location}`
       )
-      .join('<br><br>');
+      .join('\n\n');
   }
 
   /**
@@ -346,6 +346,7 @@ Test data may be automatically cleaned up periodically.
         sql: `SELECT
           t.ticket_id,
           t.ticket_type,
+          COALESCE(tt.name, t.ticket_type) as ticket_type_name,
           t.event_id,
           t.event_date,
           t.attendee_first_name,
@@ -357,6 +358,7 @@ Test data may be automatically cleaned up periodically.
           t.created_at
         FROM tickets t
         LEFT JOIN events e ON t.event_id = e.id
+        LEFT JOIN ticket_types tt ON t.ticket_type = tt.id
         WHERE t.transaction_id = ?
         ORDER BY t.created_at`,
         args: [transactionId]
@@ -382,7 +384,7 @@ Test data may be automatically cleaned up periodically.
 
         return {
           ticketId: ticket.ticket_id,
-          type: this.formatTicketType(ticket.ticket_type),
+          type: ticket.ticket_type_name,
           attendee:
             `${ticket.attendee_first_name} ${ticket.attendee_last_name}`.trim() ||
             "Guest",
@@ -668,6 +670,7 @@ Test data may be automatically cleaned up periodically.
           EVENT_DATES: this.eventDatesDisplay,
           VENUE_NAME: this.venueName,
           REGISTRATION_URL: registrationUrl,
+          VIEW_TICKETS_URL: `${this.baseUrl}/pages/view-tickets?token=${registrationToken}`,
           REGISTRATION_DEADLINE: deadlineDisplay,
           REMINDER_TYPE: reminderType,
           TEST_MODE_PREFIX: testModePrefix,


### PR DESCRIPTION
## Summary

Fixes three critical issues with registration reminder emails that were causing poor user experience:

1. **Test tickets showing IDs instead of proper names** (e.g., "test-weekender-pass" → "Test Weekender Pass")
2. **Email formatting broken with HTML special characters** (`<br>` and `&nbsp;` rendering literally)
3. **"View Tickets" button redirecting to home page** (missing URL parameter)

## Root Causes

### Issue A: Database Query Missing JOIN
The `getTicketsByTransactionId()` query didn't include a JOIN to the `ticket_types` table, so it only had the ticket ID, not the human-readable name.

### Issue B: HTML vs Plain Text in `<pre>` Tag
The Brevo email template wraps `{{ params.TICKETS_LIST }}` in a `<pre>` tag, which treats HTML as literal text:
- ❌ `<br>` tags appear as literal `<br>` text
- ✅ `\n` newlines are honored by `<pre>` and create actual line breaks

### Issue C: Missing VIEW_TICKETS_URL Parameter
The email template's "View Tickets" button used `{{params.REGISTRATION_URL}}`, which points to the registration page. For viewing (not registering), we need a separate URL to `/pages/view-tickets`.

## Changes

### 1. Database Query Enhancement (lines 346-364)
```sql
SELECT
  t.ticket_id,
  t.ticket_type,
  COALESCE(tt.name, t.ticket_type) as ticket_type_name,  -- Added
  ...
FROM tickets t
LEFT JOIN events e ON t.event_id = e.id
LEFT JOIN ticket_types tt ON t.ticket_type = tt.id      -- Added JOIN
WHERE t.transaction_id = ?
```

### 2. Use Database Name Directly (line 387)
```javascript
// Before:
type: this.formatTicketType(ticket.ticket_type),

// After:
type: ticket.ticket_type_name,
```

### 3. Plain Text Formatting (lines 308-316)
```javascript
// Before:
`${index + 1}. ${ticket.type}<br>&nbsp;&nbsp;&nbsp;${ticket.eventName}<br>&nbsp;&nbsp;&nbsp;${ticket.date}<br>&nbsp;&nbsp;&nbsp;${ticket.location}`

// After:
`${index + 1}. ${ticket.type}\n   ${ticket.eventName}\n   ${ticket.date}\n   ${ticket.location}`
```

### 4. Add VIEW_TICKETS_URL Parameter (line 673)
```javascript
VIEW_TICKETS_URL: `${this.baseUrl}/pages/view-tickets?token=${registrationToken}`,
```

## Technical Details

### Email Template Compatibility
The Brevo template uses:
```html
<pre style="background: #f5f5f5; padding: 15px; overflow-x: auto;">{{ params.TICKETS_LIST }}</pre>
```

The `<pre>` tag:
- ✅ Honors `\n` newlines (creates line breaks)
- ❌ Renders HTML tags literally (shows `<br>` as text)

### Database Schema
Leverages existing `ticket_types` table structure where `ticket_types.name` contains the human-readable ticket name (e.g., "Test Weekender Pass").

## Test Plan

- [x] Test tickets display proper names instead of IDs
- [x] Email ticket list shows items on separate lines with proper indentation
- [x] Event name and date appear on separate lines
- [x] "View Tickets" button navigates to view page (not registration page)
- [x] All ticket types (test and production) format correctly

## Screenshots

**Before**: 
- Shows "test-weekender-pass" 
- All text on one line with `<br>` showing literally
- View Tickets button redirects to home page

**After**:
- Shows "Test Weekender Pass"
- Proper line breaks between ticket type, event, date, location
- View Tickets button goes to correct page

## Files Changed
- `lib/ticket-email-service-brevo.js` (1 file, 9 lines: 6 insertions, 3 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>