### PR TITLE
feat: add ticket-specific event times and fix Mountain Time display

### DIFF
--- a/api/events/list.js
+++ b/api/events/list.js
@@ -167,7 +167,8 @@ function generateDisplayName(event) {
     if (event.type === 'weekender') {
         const monthYear = new Date(event.start_date).toLocaleDateString('en-US', {
             month: 'long',
-            year: 'numeric'
+            year: 'numeric',
+            timeZone: 'America/Denver'
         });
         return `${monthYear} ${typeDisplay} Tickets`;
     }

--- a/api/registration/batch.js
+++ b/api/registration/batch.js
@@ -103,7 +103,8 @@ Registration Date: ${new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
+    timeZone: 'America/Denver'
   })}
 Total Tickets Registered: ${results.length}
 
@@ -142,7 +143,8 @@ This is an automated confirmation email for your ticket registration.`;
           weekday: 'long',
           year: 'numeric',
           month: 'long',
-          day: 'numeric'
+          day: 'numeric',
+          timeZone: 'America/Denver'
         })}</p>
         <p><strong>Total Tickets Registered:</strong> ${results.length}</p>
       </div>
@@ -679,7 +681,7 @@ export default async function handler(req, res) {
 
           // Format event date
           const eventDate = task.ticket.start_date && task.ticket.end_date
-            ? `${new Date(task.ticket.start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}-${new Date(task.ticket.end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`
+            ? `${new Date(task.ticket.start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', timeZone: 'America/Denver' })}-${new Date(task.ticket.end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'America/Denver' })}`
             : 'May 15-17, 2026';
 
           // Generate HTML email using template

--- a/api/tickets/register.js
+++ b/api/tickets/register.js
@@ -300,7 +300,7 @@ export default async function handler(req, res) {
 
       // Format event date
       const eventDate = ticket.start_date && ticket.end_date
-        ? `${new Date(ticket.start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}-${new Date(ticket.end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`
+        ? `${new Date(ticket.start_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', timeZone: 'America/Denver' })}-${new Date(ticket.end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'America/Denver' })}`
         : 'May 15-17, 2026';
 
       // Generate HTML email using template

--- a/api/tickets/types.js
+++ b/api/tickets/types.js
@@ -66,7 +66,9 @@ export default async function handler(req, res) {
       event: {
         id: ticket.event_id,
         name: ticket.event_name,
-        date: ticket.event_date,
+        date: ticket.event_date,           // Ticket type's valid from date
+        time: ticket.event_time,           // Ticket type's valid from time
+        start_date: ticket.event_start_date, // Event's overall start date
         venue: ticket.event_venue,
         status: ticket.event_status
       }

--- a/config/bootstrap.json
+++ b/config/bootstrap.json
@@ -79,8 +79,8 @@
       "venue_city": "Boulder",
       "venue_state": "CO",
       "venue_zip": "80301",
-      "start_date": "2028-01-01",
-      "end_date": "2028-01-03",
+      "start_date": "2028-01-07",
+      "end_date": "2028-01-09",
       "max_capacity": 100,
       "early_bird_end_date": "2027-12-01",
       "regular_price_start_date": "2027-12-15",
@@ -100,8 +100,8 @@
       "venue_city": "Boulder",
       "venue_state": "CO",
       "venue_zip": "80301",
-      "start_date": "2028-01-01",
-      "end_date": "2028-01-02",
+      "start_date": "2028-01-07",
+      "end_date": "2028-01-08",
       "max_capacity": 50,
       "early_bird_end_date": "2027-12-01",
       "regular_price_start_date": "2027-12-15",
@@ -117,6 +117,8 @@
       "event_id": 2,
       "name": "Full Pass",
       "description": "Full weekend access to workshops and socials",
+      "event_date": "2025-11-08",
+      "event_time": "13:00",
       "price_cents": 6500,
       "status": "available",
       "display_order": 1
@@ -126,6 +128,8 @@
       "event_id": 2,
       "name": "Single Class",
       "description": "Access to one workshop session",
+      "event_date": "2025-11-08",
+      "event_time": "13:00",
       "price_cents": 2500,
       "status": "available",
       "display_order": 2
@@ -135,6 +139,8 @@
       "event_id": 3,
       "name": "Early Bird Full Pass",
       "description": "Special early pricing for full festival access",
+      "event_date": "2026-05-15",
+      "event_time": "18:00",
       "price_cents": null,
       "status": "coming-soon",
       "display_order": 1
@@ -144,6 +150,8 @@
       "event_id": 3,
       "name": "Full Festival Pass",
       "description": "Complete 3-day festival experience",
+      "event_date": "2026-05-15",
+      "event_time": "18:00",
       "price_cents": null,
       "status": "coming-soon",
       "display_order": 2
@@ -153,6 +161,8 @@
       "event_id": 3,
       "name": "Friday Pass",
       "description": "Friday workshops and social dance",
+      "event_date": "2026-05-15",
+      "event_time": "16:00",
       "price_cents": null,
       "status": "coming-soon",
       "display_order": 3
@@ -162,6 +172,8 @@
       "event_id": 3,
       "name": "Saturday Pass",
       "description": "Saturday workshops and social dance",
+      "event_date": "2026-05-16",
+      "event_time": "11:00",
       "price_cents": null,
       "status": "coming-soon",
       "display_order": 4
@@ -171,6 +183,8 @@
       "event_id": 3,
       "name": "Sunday Pass",
       "description": "Sunday workshops and social dance",
+      "event_date": "2026-05-17",
+      "event_time": "11:00",
       "price_cents": null,
       "status": "coming-soon",
       "display_order": 5
@@ -180,6 +194,8 @@
       "event_id": -2,
       "name": "[TEST] VIP Pass",
       "description": "Full festival access with VIP perks including exclusive areas and early entry",
+      "event_date": "2028-01-07",
+      "event_time": "12:00",
       "price_cents": 15000,
       "status": "test",
       "display_order": 1
@@ -189,6 +205,8 @@
       "event_id": -1,
       "name": "[TEST] Weekender Pass",
       "description": "Access to all weekend events Friday through Sunday",
+      "event_date": "2028-01-07",
+      "event_time": "12:00",
       "price_cents": 7500,
       "status": "test",
       "display_order": 2
@@ -198,6 +216,8 @@
       "event_id": -2,
       "name": "[TEST] Friday Pass",
       "description": "Friday night social and performances",
+      "event_date": "2028-01-07",
+      "event_time": "12:00",
       "price_cents": 3500,
       "status": "test",
       "display_order": 3
@@ -207,6 +227,8 @@
       "event_id": -2,
       "name": "[TEST] Saturday Pass",
       "description": "Saturday workshops and evening social",
+      "event_date": "2028-01-08",
+      "event_time": "12:00",
       "price_cents": 3500,
       "status": "test",
       "display_order": 4
@@ -216,6 +238,8 @@
       "event_id": -2,
       "name": "[TEST] Sunday Pass",
       "description": "Sunday workshops and closing performance",
+      "event_date": "2028-01-09",
+      "event_time": "12:00",
       "price_cents": 3500,
       "status": "test",
       "display_order": 5

--- a/js/admin-api-endpoints.js
+++ b/js/admin-api-endpoints.js
@@ -250,7 +250,7 @@ class EndpointManager {
             <span class="history-status">${statusIcon}</span>
           </div>
           <div class="history-details">
-            <span class="history-time">${new Date(req.timestamp).toLocaleTimeString()}</span>
+            <span class="history-time">${new Date(req.timestamp).toLocaleTimeString('en-US', { timeZone: 'America/Denver' })}</span>
             <span class="history-duration">${Math.round(req.duration)}ms</span>
             ${req.status ? `<span class="history-http-status">${req.status}</span>` : ''}
           </div>

--- a/js/admin-donations.js
+++ b/js/admin-donations.js
@@ -150,7 +150,7 @@ function renderDonationsTable(donations) {
   }
 
   tbody.innerHTML = donations.map(donation => {
-    const date = donation.created_at_mt || new Date(donation.created_at).toLocaleDateString();
+    const date = donation.created_at_mt || new Date(donation.created_at).toLocaleDateString('en-US', { timeZone: 'America/Denver' });
     const amount = `$${Number(donation.amount).toFixed(2)}`;
     const customer = donation.customer_name || donation.customer_email || 'N/A';
     const event = donation.event_name || 'N/A';
@@ -222,7 +222,7 @@ function exportCSV() {
   // CSV rows
   const rows = donationsData.donations.map(donation => {
     return [
-      donation.created_at_mt || new Date(donation.created_at).toLocaleDateString(),
+      donation.created_at_mt || new Date(donation.created_at).toLocaleDateString('en-US', { timeZone: 'America/Denver' }),
       donation.transaction_id || 'N/A',
       Number(donation.amount).toFixed(2),
       donation.customer_name || donation.customer_email || 'N/A',

--- a/js/ticket-selection.js
+++ b/js/ticket-selection.js
@@ -272,7 +272,8 @@ class TicketSelection {
                             const formattedDate = date.toLocaleDateString('en-US', {
                                 year: 'numeric',
                                 month: 'long',
-                                day: 'numeric'
+                                day: 'numeric',
+                                timeZone: 'America/Denver'
                             });
                             dateElement.textContent = formattedDate;
                             dateElement.removeAttribute('data-loading');

--- a/lib/apple-wallet-service.js
+++ b/lib/apple-wallet-service.js
@@ -466,8 +466,8 @@ export class AppleWalletService {
       // Logo: wallet-logo.png banner image (Apple controls positioning)
       // Barcodes removed from constructor - will be set after pass.type using setBarcodes()
 
-      // Relevance information
-      relevantDate: this.eventStartDate,
+      // Relevance information - Use ticket's event_date and event_time
+      relevantDate: this.buildMountainTimeISO(ticket.event_date, ticket.event_time),
       locations: [
         {
           latitude: this.venueLatitude,
@@ -823,6 +823,52 @@ export class AppleWalletService {
       ) VALUES (?, ?, ?)`,
       args: [passSerial, eventType, JSON.stringify(eventData)],
     });
+  }
+
+  /**
+   * Build ISO 8601 datetime string in Mountain Time
+   * @param {string} date - Date in YYYY-MM-DD format
+   * @param {string} time - Time in HH:MM format
+   * @returns {string} ISO datetime in Mountain Time (e.g., "2026-05-15T14:00:00-06:00")
+   */
+  buildMountainTimeISO(date, time) {
+    if (!date || !time) {
+      console.warn('Missing date or time for buildMountainTimeISO, using fallback');
+      return this.eventStartDate || new Date().toISOString();
+    }
+
+    // Combine date and time
+    const dateTimeString = `${date}T${time}:00`;
+
+    // Create date object (will be in local time zone)
+    const dateObj = new Date(dateTimeString);
+
+    // Format in Mountain Time
+    const mtFormatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/Denver',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    });
+
+    const parts = mtFormatter.formatToParts(dateObj);
+    const partsMap = {};
+    parts.forEach(part => {
+      partsMap[part.type] = part.value;
+    });
+
+    // Determine offset (MST = -07:00, MDT = -06:00)
+    // Simple heuristic: DST typically Mar-Nov in US
+    const month = parseInt(partsMap.month);
+    const isDST = month >= 3 && month <= 10;
+    const offset = isDST ? '-06:00' : '-07:00';
+
+    // Build ISO string
+    return `${date}T${time}:00${offset}`;
   }
 }
 

--- a/lib/bootstrap-schema.js
+++ b/lib/bootstrap-schema.js
@@ -303,6 +303,18 @@ export class BootstrapSchemaValidator {
         result.addError(`${prefix}.event_id`, 'Must be an integer');
       }
 
+      // Validate event_date (required)
+      this.validateRequiredField(ticket, 'event_date', 'string', prefix, result);
+      if (ticket.event_date) {
+        this.validateDate(ticket.event_date, `${prefix}.event_date`, result);
+      }
+
+      // Validate event_time (required, HH:MM format)
+      this.validateRequiredField(ticket, 'event_time', 'string', prefix, result);
+      if (ticket.event_time) {
+        this.validateTime(ticket.event_time, `${prefix}.event_time`, result);
+      }
+
       // Validate status enum
       if (ticket.status && !this.allowedTicketStatuses.includes(ticket.status)) {
         result.addError(
@@ -528,6 +540,33 @@ export class BootstrapSchemaValidator {
 
     if (utcYear !== year || utcMonth !== month || utcDay !== day) {
       result.addError(fieldPath, `Invalid date: ${dateString} (e.g., month/day overflow)`);
+    }
+  }
+
+  /**
+   * Helper: Validate time format (HH:MM)
+   */
+  validateTime(timeString, fieldPath, result) {
+    if (!timeString) return;
+
+    // Check HH:MM format
+    if (!/^\d{2}:\d{2}$/.test(timeString)) {
+      result.addError(fieldPath, 'Must be in HH:MM format (e.g., "14:00", "09:30")');
+      return;
+    }
+
+    // Parse components
+    const [hour, minute] = timeString.split(':').map(Number);
+
+    // Validate ranges
+    if (hour < 0 || hour > 23) {
+      result.addError(fieldPath, `Invalid hour: ${hour} (must be 0-23)`);
+      return;
+    }
+
+    if (minute < 0 || minute > 59) {
+      result.addError(fieldPath, `Invalid minute: ${minute} (must be 0-59)`);
+      return;
     }
   }
 

--- a/lib/bootstrap-service.js
+++ b/lib/bootstrap-service.js
@@ -276,8 +276,9 @@ class BootstrapService {
             INSERT INTO ticket_types (
               id, event_id, stripe_price_id, name, description,
               price_cents, currency, status, max_quantity,
-              sold_count, display_order, metadata, availability
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              sold_count, display_order, metadata, availability,
+              event_date, event_time
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
               event_id = excluded.event_id,
               stripe_price_id = excluded.stripe_price_id,
@@ -290,12 +291,16 @@ class BootstrapService {
               display_order = excluded.display_order,
               metadata = excluded.metadata,
               availability = excluded.availability,
+              event_date = excluded.event_date,
+              event_time = excluded.event_time,
               updated_at = CURRENT_TIMESTAMP
             WHERE
               ticket_types.stripe_price_id != excluded.stripe_price_id OR
               ticket_types.price_cents != excluded.price_cents OR
               ticket_types.status != excluded.status OR
-              ticket_types.metadata != excluded.metadata
+              ticket_types.metadata != excluded.metadata OR
+              ticket_types.event_date != excluded.event_date OR
+              ticket_types.event_time != excluded.event_time
           `,
           args: [
             ticketId,
@@ -310,7 +315,9 @@ class BootstrapService {
             ticket.sold_count || 0,
             ticket.display_order || ticket.sort_order || 0, // Accept both display_order and sort_order (legacy)
             JSON.stringify({}), // Empty metadata for now
-            JSON.stringify({}) // Empty availability for now
+            JSON.stringify({}), // Empty availability for now
+            ticket.event_date,
+            ticket.event_time || '00:00'
           ]
         });
       }

--- a/lib/google-wallet-service.js
+++ b/lib/google-wallet-service.js
@@ -308,8 +308,10 @@ export class GoogleWalletService {
       // DEBUG: Log actual date values from database
       console.log('[GoogleWallet] Ticket dates:', {
         ticket_id: ticketId,
-        start_date: ticket.start_date,
-        end_date: ticket.end_date,
+        event_date: ticket.event_date,        // Ticket's valid from date
+        event_time: ticket.event_time,        // Ticket's valid from time
+        start_date: ticket.start_date,        // Event's start date
+        end_date: ticket.end_date,            // Event's end date
         event_name: ticket.event_name,
         event_id: ticket.event_id
       });
@@ -407,10 +409,12 @@ export class GoogleWalletService {
         linkedOfferIds: [],
         validTimeInterval: {
           start: {
-            date: this.formatDateTimeForWallet(ticket.start_date, false),
+            // Use ticket's event_date and event_time (when ticket becomes valid)
+            date: this.formatDateTimeForWallet(ticket.event_date, ticket.event_time, false),
           },
           end: {
-            date: this.formatDateTimeForWallet(ticket.end_date, true),
+            // Use event's end_date (when event finishes)
+            date: this.formatDateTimeForWallet(ticket.end_date, '23:59', true),
           },
         },
         // Custom styled fields to match Apple Wallet
@@ -475,7 +479,8 @@ export class GoogleWalletService {
             body: "Show this ticket at the entrance for scanning.",
             displayInterval: {
               start: {
-                date: this.formatDateTimeForWallet(ticket.start_date, false),
+                // Use ticket's event_date and event_time (when ticket becomes valid)
+                date: this.formatDateTimeForWallet(ticket.event_date, ticket.event_time, false),
               },
             },
           },
@@ -660,17 +665,36 @@ export class GoogleWalletService {
    * @param {boolean} isEndDate - If true, set time to 23:59:59 (end of day)
    * @returns {string} ISO 8601 datetime string with Mountain Time offset
    */
-  formatDateTimeForWallet(dateString, isEndDate = false) {
+  formatDateTimeForWallet(dateString, timeOrEndFlag = false, isEndDate = false) {
     if (!dateString) {
       throw new Error('Date string is required');
     }
 
     const date = new Date(dateString);
 
-    // Set time based on whether it's start or end of day
-    const hours = isEndDate ? 23 : 0;
-    const minutes = isEndDate ? 59 : 0;
-    const seconds = isEndDate ? 59 : 0;
+    // Handle overloaded parameters
+    // If timeOrEndFlag is a boolean, treat it as isEndDate (backward compatibility)
+    // If timeOrEndFlag is a string, treat it as time in HH:MM format
+    let hours, minutes, seconds;
+
+    if (typeof timeOrEndFlag === 'boolean') {
+      // Legacy mode: boolean indicates end of day
+      isEndDate = timeOrEndFlag;
+      hours = isEndDate ? 23 : 0;
+      minutes = isEndDate ? 59 : 0;
+      seconds = isEndDate ? 59 : 0;
+    } else if (typeof timeOrEndFlag === 'string') {
+      // New mode: time string in HH:MM format
+      const timeParts = timeOrEndFlag.split(':');
+      hours = parseInt(timeParts[0]) || 0;
+      minutes = parseInt(timeParts[1]) || 0;
+      seconds = 0;
+    } else {
+      // Default: start of day
+      hours = 0;
+      minutes = 0;
+      seconds = 0;
+    }
 
     // LIMITATION: Fixed MST offset (-07:00), does not account for DST
     // See detailed explanation in method documentation above

--- a/lib/ticket-cache-service.js
+++ b/lib/ticket-cache-service.js
@@ -455,7 +455,8 @@ class TicketCacheService {
         weekday: 'long',
         year: 'numeric',
         month: 'long',
-        day: 'numeric'
+        day: 'numeric',
+        timeZone: 'America/Denver'
       });
     } catch (error) {
       return 'May 15-17, 2026';

--- a/lib/ticket-creation-service.js
+++ b/lib/ticket-creation-service.js
@@ -476,22 +476,27 @@ async function createTicketsForTransaction(fullSession, transaction) {
         }
       };
 
+      // Use event_date and event_time from validated ticket_type record (authoritative source)
+      const ticketEventDate = ticketTypeRecord?.event_date || eventDate;
+      const ticketEventTime = ticketTypeRecord?.event_time || '00:00';
+
       // Add ticket creation operation to batch
       batchOperations.push({
         sql: `INSERT INTO tickets (
           ticket_id, transaction_id, ticket_type, ticket_type_id, event_id,
-          event_date, price_cents,
+          event_date, event_time, price_cents,
           attendee_first_name, attendee_last_name,
           registration_status, registration_deadline,
           status, created_at, is_test, ticket_metadata
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         args: [
           ticketId,
           transaction.id,
           ticketType,  // No TEST- prefix - already handled by admin dashboard
           ticketType,  // ticket_type_id uses same value (ticket_types.id is TEXT)
           eventId,
-          eventDate,
+          ticketEventDate,
+          ticketEventTime,
           priceForThisTicket,
           isTestTransaction ? `TEST-${firstName}` : firstName,
           isTestTransaction ? `TEST-${lastName}` : lastName,

--- a/lib/ticket-email-service-brevo.js
+++ b/lib/ticket-email-service-brevo.js
@@ -367,7 +367,8 @@ Test data may be automatically cleaned up periodically.
       day: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
-      timeZoneName: 'short'
+      timeZoneName: 'short',
+      timeZone: 'America/Denver'
     });
   }
 
@@ -630,7 +631,8 @@ Test data may be automatically cleaned up periodically.
         day: "numeric",
         hour: "numeric",
         minute: "2-digit",
-        timeZoneName: "short"
+        timeZoneName: "short",
+        timeZone: "America/Denver"
       });
 
       // Create registration URL
@@ -775,7 +777,8 @@ Test data may be automatically cleaned up periodically.
         day: "numeric",
         hour: "numeric",
         minute: "2-digit",
-        timeZoneName: "short"
+        timeZoneName: "short",
+        timeZone: "America/Denver"
       });
 
       // Calculate time remaining

--- a/lib/ticket-email-service.js
+++ b/lib/ticket-email-service.js
@@ -174,6 +174,7 @@ export class TicketEmailService {
       year: "numeric",
       month: "long",
       day: "numeric",
+      timeZone: "America/Denver"
     });
   }
 

--- a/lib/ticket-service.js
+++ b/lib/ticket-service.js
@@ -592,6 +592,7 @@ export class TicketService {
       year: "numeric",
       month: "long",
       day: "numeric",
+      timeZone: "America/Denver"
     });
   }
 

--- a/lib/ticket-type-cache.js
+++ b/lib/ticket-type-cache.js
@@ -83,7 +83,7 @@ class TicketTypeCache {
           SELECT
             tt.*,
             e.name as event_name,
-            e.start_date as event_date,
+            e.start_date as event_start_date,
             e.venue_name as event_venue,
             e.status as event_status
           FROM ticket_types tt
@@ -132,7 +132,7 @@ class TicketTypeCache {
           SELECT
             tt.*,
             e.name as event_name,
-            e.start_date as event_date,
+            e.start_date as event_start_date,
             e.venue_name as event_venue,
             e.status as event_status
           FROM ticket_types tt
@@ -216,7 +216,7 @@ class TicketTypeCache {
           SELECT
             tt.*,
             e.name as event_name,
-            e.start_date as event_date,
+            e.start_date as event_start_date,
             e.venue_name as event_venue,
             e.status as event_status
           FROM ticket_types tt

--- a/migrations/039_ticket_type_event_datetime.sql
+++ b/migrations/039_ticket_type_event_datetime.sql
@@ -1,0 +1,19 @@
+-- Migration: 039 - Ticket Type Event Date/Time
+-- Purpose: Add event_date and event_time to ticket_types and tickets
+-- Dependencies: 022_ticket_types_table.sql, 005_tickets.sql
+
+-- Add event_date and event_time to ticket_types
+-- These define when the ticket type becomes valid (e.g., Friday Pass valid from Friday 2:00 PM)
+ALTER TABLE ticket_types ADD COLUMN event_date DATE NOT NULL DEFAULT '2026-01-01';
+ALTER TABLE ticket_types ADD COLUMN event_time TIME NOT NULL DEFAULT '00:00';
+
+-- Add event_time to tickets (event_date already exists)
+-- Tickets inherit event_date and event_time from their ticket_type
+ALTER TABLE tickets ADD COLUMN event_time TIME NOT NULL DEFAULT '00:00';
+
+-- Create index for ticket validity queries
+CREATE INDEX IF NOT EXISTS idx_ticket_types_event_datetime
+  ON ticket_types(event_date, event_time);
+
+CREATE INDEX IF NOT EXISTS idx_tickets_event_datetime
+  ON tickets(event_date, event_time);

--- a/pages/admin/analytics.html
+++ b/pages/admin/analytics.html
@@ -1336,6 +1336,7 @@
           month: "short",
           day: "numeric",
           year: "numeric",
+          timeZone: "America/Denver"
         });
       }
 
@@ -1358,6 +1359,7 @@
             now.toLocaleTimeString("en-US", {
               hour: "2-digit",
               minute: "2-digit",
+              timeZone: "America/Denver"
             });
         }
       }

--- a/pages/admin/dashboard.html
+++ b/pages/admin/dashboard.html
@@ -784,8 +784,8 @@
 
         const rows = events.map(event => {
           const statusColor = statusColors[event.status] || 'secondary';
-          const startDate = event.start_date ? (timeManager ? timeManager.formatDate(event.start_date) : new Date(event.start_date).toLocaleDateString()) : 'TBA';
-          const endDate = event.end_date ? (timeManager ? timeManager.formatDate(event.end_date) : new Date(event.end_date).toLocaleDateString()) : 'TBA';
+          const startDate = event.start_date ? (timeManager ? timeManager.formatDate(event.start_date) : new Date(event.start_date).toLocaleDateString('en-US', { timeZone: 'America/Denver' })) : 'TBA';
+          const endDate = event.end_date ? (timeManager ? timeManager.formatDate(event.end_date) : new Date(event.end_date).toLocaleDateString('en-US', { timeZone: 'America/Denver' })) : 'TBA';
 
           return `
             <tr>

--- a/pages/admin/database-dashboard.html
+++ b/pages/admin/database-dashboard.html
@@ -884,7 +884,7 @@
 
         function updateLastUpdatedTime() {
             const lastUpdated = document.getElementById('lastUpdated');
-            lastUpdated.textContent = `Last updated: ${new Date().toLocaleTimeString()}`;
+            lastUpdated.textContent = `Last updated: ${new Date().toLocaleTimeString('en-US', { timeZone: 'America/Denver' })}`;
         }
 
         // Refresh functions for individual components

--- a/pages/admin/donations.html
+++ b/pages/admin/donations.html
@@ -359,7 +359,8 @@
           now.toLocaleTimeString('en-US', {
             hour: '2-digit',
             minute: '2-digit',
-            second: '2-digit'
+            second: '2-digit',
+            timeZone: 'America/Denver'
           });
       }
       updateTime();

--- a/pages/admin/index.html
+++ b/pages/admin/index.html
@@ -1485,7 +1485,7 @@
                 </div>
               </div>
               <div class="history-entry-time">
-                ${window.timeManager ? window.timeManager.formatDateTime(entry.timestamp) : new Date(entry.timestamp).toLocaleString()}
+                ${window.timeManager ? window.timeManager.formatDateTime(entry.timestamp) : new Date(entry.timestamp).toLocaleString('en-US', { timeZone: 'America/Denver' })}
                 ${entry.response.timing ? ` • ${entry.response.timing}ms` : ''}
               </div>
             </div>
@@ -1915,7 +1915,7 @@
           });
           const data = await response.json();
           alert(
-            `CSRF Token Info:\n\nToken: ${data.csrfToken.substring(0, 20)}...\nExpires: ${window.timeManager ? window.timeManager.formatDateTime(new Date(Date.now() + 3600000)) : new Date(Date.now() + 3600000).toLocaleString()} (MT)`,
+            `CSRF Token Info:\n\nToken: ${data.csrfToken.substring(0, 20)}...\nExpires: ${window.timeManager ? window.timeManager.formatDateTime(new Date(Date.now() + 3600000)) : new Date(Date.now() + 3600000).toLocaleString('en-US', { timeZone: 'America/Denver' })} (MT)`,
           );
         } catch (error) {
           alert("Failed to fetch CSRF token");

--- a/pages/admin/mfa-settings.html
+++ b/pages/admin/mfa-settings.html
@@ -452,7 +452,7 @@
         const statusIcon = isEnabled ? "✅" : "❌";
         const statusTitle = isEnabled ? "MFA is Enabled" : "MFA is Disabled";
         const statusDesc = isEnabled
-          ? `Enabled on ${window.timeManager ? window.timeManager.formatDate(mfaStatus.enabledAt) : new Date(mfaStatus.enabledAt).toLocaleDateString()}`
+          ? `Enabled on ${window.timeManager ? window.timeManager.formatDate(mfaStatus.enabledAt) : new Date(mfaStatus.enabledAt).toLocaleDateString('en-US', { timeZone: 'America/Denver' })}`
           : "Your account is not protected by multi-factor authentication";
 
         container.innerHTML = `

--- a/pages/admin/registrations.html
+++ b/pages/admin/registrations.html
@@ -319,7 +319,7 @@
               <td>${escapeHtml(reg.email || '')}</td>
               <td>${escapeHtml(reg.ticketType || '')}</td>
               <td>${escapeHtml(reg.registrationStatus || '')}</td>
-              <td>${reg.registeredAt ? (timeManager ? timeManager.formatDateTime(reg.registeredAt) : new Date(reg.registeredAt).toLocaleDateString()) : 'N/A'}</td>
+              <td>${reg.registeredAt ? (timeManager ? timeManager.formatDateTime(reg.registeredAt) : new Date(reg.registeredAt).toLocaleDateString('en-US', { timeZone: 'America/Denver' })) : 'N/A'}</td>
               <td>${reg.checkedIn ? 'Yes' : 'No'}</td>
               <td>${reg.purchaserEmail || ''}</td>
             </tr>


### PR DESCRIPTION
## Summary
Add event-specific start times for individual ticket types and fix 25 critical timezone display issues where dates/times were showing in UTC or browser timezone instead of Mountain Time (America/Denver).

## Changes
- **New Database Schema**: Added `event_date` and `event_time` columns to `ticket_types` table (migration 039)
- **Ticket Type Configuration**: All 12 ticket types now have specific start times:
  - Weekender passes: 1:00 PM (13:00)
  - Boulder Fest Full/Early Bird: 6:00 PM (18:00)
  - Friday Pass: 4:00 PM (16:00)
  - Saturday/Sunday Passes: 11:00 AM (11:00)
- **Wallet Pass Integration**: Updated Apple and Google Wallet services with Mountain Time ISO formatting
- **Bootstrap System**: Enhanced schema validation for HH:MM time format
- **Critical Timezone Fixes** (25 instances):
  - **Email Services** (3 fixes): Registration deadlines now display in Mountain Time instead of UTC
  - **Admin Pages** (13 fixes): All admin displays corrected to use America/Denver timezone
  - **API Endpoints** (5 fixes): Registration and event APIs properly formatted
  - **Service Libraries** (3 fixes): Ticket services use correct timezone
  - **Frontend** (1 fix): Ticket selection displays Mountain Time

## Context
This change addresses two critical requirements:

1. **Ticket-Specific Timing**: Different ticket types need different validity start times. For example, a Friday Pass should be valid from Friday 4:00 PM, while a Saturday Pass is valid from Saturday 11:00 AM. This was previously impossible as only event-level dates existed.

2. **Timezone Display Bug**: User-reported issue (screenshot evidence) showed registration reminder emails displaying "11:40 PM UTC" instead of Mountain Time. This affected:
   - Registration deadline emails (critical user communication)
   - Admin dashboards and reports
   - API responses and frontend displays

## Testing
- ✅ All linting checks passed
- ✅ Bootstrap schema validation includes new time fields
- ✅ Migration 039 adds indexed columns with proper defaults
- ✅ Package drift check passed
- CI/CD will run full test suite

## Database Migration
Migration 039 adds:
```sql
ALTER TABLE ticket_types ADD COLUMN event_date DATE NOT NULL DEFAULT '2026-01-01';
ALTER TABLE ticket_types ADD COLUMN event_time TIME NOT NULL DEFAULT '00:00';
ALTER TABLE tickets ADD COLUMN event_time TIME NOT NULL DEFAULT '00:00';
CREATE INDEX idx_ticket_types_event_datetime ON ticket_types(event_date, event_time);
CREATE INDEX idx_tickets_event_datetime ON tickets(event_date, event_time);
```

## Files Changed
- 26 files modified
- 227 insertions, 48 deletions
- 1 new migration file

🤖 Generated with [Claude Code](https://claude.com/claude-code)