### PR TITLE
test(e2e): expand navigation test coverage to all pages

### DIFF
--- a/tests/e2e/flows/navigation-links.test.js
+++ b/tests/e2e/flows/navigation-links.test.js
@@ -278,23 +278,45 @@ test.describe('Navigation Links - Mobile Navigation', () => {
 });
 
 test.describe('Navigation Links - Broken Link Prevention', () => {
-  test('Weekender dropdown should NOT go to tickets page', async ({ page }) => {
-    await page.goto('/home');
-    await page.waitForLoadState('networkidle');
+  test('Weekender dropdown should NOT go to tickets page on ANY page', async ({ page }) => {
+    const pagesToCheck = [
+      '/home',
+      '/about',
+      '/tickets',
+      '/contact',
+      '/donations',
+      '/boulder-fest-2026',
+      '/boulder-fest-2026/artists',
+      '/boulder-fest-2026/schedule',
+      '/boulder-fest-2026/gallery',
+      '/boulder-fest-2025',
+      '/boulder-fest-2025/artists',
+      '/boulder-fest-2025/schedule',
+      '/boulder-fest-2025/gallery',
+      '/weekender-2025-11',
+      '/weekender-2025-11/artists',
+      '/weekender-2025-11/schedule',
+      '/weekender-2025-11/gallery',
+    ];
 
-    // Open Events dropdown
-    const eventsButton = page.locator('[data-dropdown="events"]').first();
-    await eventsButton.click();
+    for (const pagePath of pagesToCheck) {
+      await page.goto(pagePath);
+      await page.waitForLoadState('networkidle');
 
-    // Click on Weekender link
-    const weekenderLink = page.getByRole('menuitem', { name: 'November 2025' });
-    await weekenderLink.click();
+      // Open Events dropdown
+      const eventsButton = page.locator('[data-dropdown="events"]').first();
+      await eventsButton.click();
 
-    // CRITICAL: Should NOT end up on tickets page
-    await expect(page).not.toHaveURL(/\/tickets/);
+      // Click on Weekender link
+      const weekenderLink = page.getByRole('menuitem', { name: 'November 2025' });
+      await weekenderLink.click();
 
-    // Should be on weekender page
-    await expect(page).toHaveURL(/\/weekender-2025-11/);
+      // CRITICAL: Should NOT end up on tickets page
+      await expect(page, `Should not go to tickets from ${pagePath}`).not.toHaveURL(/\/tickets/);
+
+      // Should be on weekender page
+      await expect(page, `Should go to weekender from ${pagePath}`).toHaveURL(/\/weekender-2025-11/);
+    }
   });
 
   test('Weekender sub-navigation should NOT redirect to home', async ({ page }) => {
@@ -316,6 +338,57 @@ test.describe('Navigation Links - Broken Link Prevention', () => {
 
       // Should be on correct weekender sub-page
       await expect(page).toHaveURL(new RegExp(`/weekender-2025-11/${linkText.toLowerCase()}`));
+    }
+  });
+});
+
+test.describe('Navigation Links - Weekender Link Consistency', () => {
+  test('Weekender dropdown should exist and link correctly on all pages', async ({ page }) => {
+    const pagesToCheck = [
+      '/home',
+      '/about',
+      '/tickets',
+      '/contact',
+      '/donations',
+      '/boulder-fest-2026',
+      '/boulder-fest-2026/artists',
+      '/boulder-fest-2026/schedule',
+      '/boulder-fest-2026/gallery',
+      '/boulder-fest-2025',
+      '/boulder-fest-2025/artists',
+      '/boulder-fest-2025/schedule',
+      '/boulder-fest-2025/gallery',
+      '/weekender-2025-11',
+      '/weekender-2025-11/artists',
+      '/weekender-2025-11/schedule',
+      '/weekender-2025-11/gallery',
+    ];
+
+    for (const pagePath of pagesToCheck) {
+      await page.goto(pagePath);
+      await page.waitForLoadState('networkidle');
+
+      // Open Events dropdown
+      const eventsButton = page.locator('[data-dropdown="events"]').first();
+      await expect(eventsButton, `Events dropdown should exist on ${pagePath}`).toBeVisible();
+      await eventsButton.click();
+
+      // Wait for dropdown to be visible
+      const dropdown = page.locator('.dropdown-menu[aria-hidden="false"]');
+      await expect(dropdown, `Events dropdown should open on ${pagePath}`).toBeVisible();
+
+      // Find the November 2025 link
+      const weekenderLink = page.getByRole('menuitem', { name: 'November 2025' });
+      await expect(weekenderLink, `Weekender link should exist in dropdown on ${pagePath}`).toBeVisible();
+
+      // Get the href attribute
+      const href = await weekenderLink.getAttribute('href');
+
+      // CRITICAL: Verify it points to /weekender-2025-11, NOT /tickets
+      expect(href, `Weekender link on ${pagePath} should point to /weekender-2025-11, not ${href}`).toBe('/weekender-2025-11');
+
+      // Close dropdown before moving to next page
+      await eventsButton.click();
     }
   });
 });


### PR DESCRIPTION
## Summary
Expands E2E navigation tests to validate weekender links across all 17 pages instead of just the home page, preventing site-wide navigation inconsistencies from reaching production.

## Changes
- Updated "Weekender dropdown should NOT go to tickets page" test to check all 17 pages (home, about, tickets, contact, donations, all boulder-fest-2026 pages, all boulder-fest-2025 pages, all weekender-2025-11 pages)
- Added comprehensive "Weekender Link Consistency" test that validates:
  - Events dropdown exists on every page
  - November 2025 weekender link exists in dropdown
  - Link correctly points to `/weekender-2025-11` (not `/tickets`)

## Context
The previous test only checked the home page, which had the correct weekender link. This allowed navigation errors on other pages to go undetected, resulting in:
- 5 pages with incorrect weekender links pointing to `/tickets` instead of `/weekender-2025-11`
- 6 event subpages missing the Weekenders dropdown entirely

These enhanced tests would have caught all 11 pages with navigation issues before they reached production.

## Testing
- Test suite validates navigation behavior across all major pages
- Provides clear error messages indicating which page has incorrect links
- Tests both navigation functionality (clicking links) and link consistency (href validation)

🤖 Generated with Claude Code